### PR TITLE
2 - Create kd tree solution for vision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "bevy-inspector-egui",
  "bevy_ecs_ldtk",
  "bevy_rapier2d",
+ "bevy_spatial",
 ]
 
 [[package]]
@@ -981,6 +982,18 @@ dependencies = [
  "serde",
  "thiserror",
  "uuid",
+]
+
+[[package]]
+name = "bevy_spatial"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53481ec687ec7bb8f8dce74f5e80672f98c0968dd7d7939bf64d29e4a2af343b"
+dependencies = [
+ "bevy",
+ "kd-tree",
+ "num-traits",
+ "typenum",
 ]
 
 [[package]]
@@ -2450,6 +2463,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kd-tree"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12a5c8da4557f8573c26673f1db6fab935255c5cf62a82d2df33d1fba07a409"
+dependencies = [
+ "num-traits",
+ "ordered-float",
+ "paste",
+ "pdqselect",
+ "rayon",
+ "typenum",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3070,6 +3097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3145,6 +3181,12 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "pdqselect"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7778906d9321dd56cde1d1ffa69a73e59dcf5fda6d366f62727adf2bd4193aee"
 
 [[package]]
 name = "percent-encoding"
@@ -3325,6 +3367,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rectangle-pack"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ bevy = "0.13.0"
 bevy-inspector-egui = "0.23.4"
 bevy_rapier2d = { version = "0.25.0"}
 bevy_ecs_ldtk = { git = "https://github.com/theshortcut/bevy_ecs_ldtk/", branch = "bevy-0.13" }
+bevy_spatial = "0.8.0"
 
 [patch.crates-io]
 bevy_ecs_tilemap = { git = "https://github.com/StarArawn/bevy_ecs_tilemap" }

--- a/src/attack.rs
+++ b/src/attack.rs
@@ -1,4 +1,5 @@
 use crate::health::Health;
+use crate::vision::InVision;
 use bevy::prelude::*;
 
 // --- Plugin ---
@@ -7,7 +8,8 @@ pub struct AttackPlugin;
 
 impl Plugin for AttackPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, attack_target);
+        app.add_systems(PreUpdate, find_attack_target)
+            .add_systems(Update, attack_target);
     }
 }
 
@@ -31,6 +33,19 @@ pub struct AttackTarget(pub Entity); // TODO: Make it contain a list of targets.
                                      // This component would always create a new AttackTarget component with the next target, if none exist.
 
 // --- Systems ---
+
+#[allow(clippy::type_complexity)]
+fn find_attack_target(
+    mut commands: Commands,
+    query: Query<(Entity, &InVision), (With<AttackStats>, Without<AttackTarget>)>,
+) {
+    for (entity, in_vision) in query.iter() {
+        if !in_vision.enemies.is_empty() {
+            let target = in_vision.enemies[0];
+            commands.entity(entity).insert(AttackTarget(target));
+        }
+    }
+}
 
 fn attack_target(
     mut commands: Commands,

--- a/src/buildings.rs
+++ b/src/buildings.rs
@@ -1,6 +1,7 @@
 use crate::health::Health;
 use crate::teams::Team;
 use crate::unit_spawning::UnitSpawner;
+use crate::vision::Visible;
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 
@@ -25,6 +26,7 @@ pub fn spawn_building(commands: &mut Commands, team: Team, x: f32, y: f32, sprit
     let mut building_entity = commands.spawn((
         team,
         Building,
+        Visible,
         Health {
             health: 10,
             max_health: 10,
@@ -39,22 +41,10 @@ pub fn spawn_building(commands: &mut Commands, team: Team, x: f32, y: f32, sprit
             time_left: 5.0,
         },
         RigidBody::KinematicPositionBased,
-        // Add below back, if building has attack and a vision range.
-        // Collider::cuboid(32.0 * 2, 32.0 * 2),
-        // Sensor,
-        CollisionGroups::new(Group::GROUP_2, Group::GROUP_1),
-        ActiveCollisionTypes::all(), // TODO: Optimize later.
-        ActiveEvents::COLLISION_EVENTS,
+        Collider::cuboid(32.0, 32.0), // Actual collider matching sprite size.
     ));
 
     let text_color = team.get_color();
-
-    building_entity.with_children(|builder| {
-        builder.spawn((
-            Collider::cuboid(32.0, 32.0), // Actual collider matching sprite size.
-            CollisionGroups::new(Group::GROUP_1, Group::GROUP_2 | Group::GROUP_3),
-        ));
-    });
 
     building_entity.with_children(|builder| {
         builder.spawn(Text2dBundle {

--- a/src/buildings.rs
+++ b/src/buildings.rs
@@ -1,5 +1,5 @@
 use crate::health::Health;
-use crate::teams::{Team, TeamEntity};
+use crate::teams::Team;
 use crate::unit_spawning::UnitSpawner;
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
@@ -23,7 +23,7 @@ pub struct BuildingGhost {
 /// Helper function to spawn a building. This is not a system.
 pub fn spawn_building(commands: &mut Commands, team: Team, x: f32, y: f32, sprite: Handle<Image>) {
     let mut building_entity = commands.spawn((
-        TeamEntity { team },
+        team,
         Building,
         Health {
             health: 10,

--- a/src/castle_fight_ldtk.rs
+++ b/src/castle_fight_ldtk.rs
@@ -4,7 +4,7 @@ use bevy_rapier2d::prelude::*;
 
 use crate::buildings::{Building, Castle};
 use crate::health::Health;
-use crate::teams::Team;
+use crate::teams::{Team, TeamAssociation};
 use crate::waypoints::{IsStartPoint, Waypoint};
 
 /*
@@ -42,8 +42,8 @@ pub struct CastleBundle {
 struct WaypointBundle {
     #[sprite_bundle]
     sprite_bundle: SpriteBundle,
-    #[with(Team::from_field)]
-    team: Team,
+    #[with(TeamAssociation::from_field)]
+    team_association: TeamAssociation,
     #[with(UnresolvedNextWaypointRef::from_field)]
     unresolved_next_waypoint: UnresolvedNextWaypointRef,
     #[with(IsStartPoint::from_field)]

--- a/src/castle_fight_ldtk.rs
+++ b/src/castle_fight_ldtk.rs
@@ -88,7 +88,6 @@ fn resolve_next_waypoint_references(
                 .entity(entity)
                 .remove::<UnresolvedNextWaypointRef>()
                 .insert(Waypoint {
-                    id: None,
                     next_waypoint: Some(next_wp_entity),
                 });
         } else {
@@ -98,7 +97,6 @@ fn resolve_next_waypoint_references(
                 .entity(entity)
                 .remove::<UnresolvedNextWaypointRef>()
                 .insert(Waypoint {
-                    id: None,
                     next_waypoint: None,
                 });
         }

--- a/src/castle_fight_ldtk.rs
+++ b/src/castle_fight_ldtk.rs
@@ -4,7 +4,7 @@ use bevy_rapier2d::prelude::*;
 
 use crate::buildings::{Building, Castle};
 use crate::health::Health;
-use crate::teams::TeamEntity;
+use crate::teams::Team;
 use crate::waypoints::{IsStartPoint, Waypoint};
 
 /*
@@ -31,8 +31,8 @@ pub struct CastleBundle {
     building: Building,
     #[sprite_bundle]
     sprite_bundle: SpriteBundle,
-    #[with(TeamEntity::from_field)]
-    team_entity: TeamEntity,
+    #[with(Team::from_field)]
+    team: Team,
     #[with(Health::from_field)]
     health: Health,
 }
@@ -42,8 +42,8 @@ pub struct CastleBundle {
 struct WaypointBundle {
     #[sprite_bundle]
     sprite_bundle: SpriteBundle,
-    #[with(TeamEntity::from_field)]
-    team_entity: TeamEntity,
+    #[with(Team::from_field)]
+    team: Team,
     #[with(UnresolvedNextWaypointRef::from_field)]
     unresolved_next_waypoint: UnresolvedNextWaypointRef,
     #[with(IsStartPoint::from_field)]
@@ -105,11 +105,8 @@ fn resolve_next_waypoint_references(
     }
 }
 
-fn process_castle(
-    mut commands: Commands,
-    new_castles: Query<(Entity, &TeamEntity), Added<Castle>>,
-) {
-    for (entity, team_entity) in new_castles.iter() {
+fn process_castle(mut commands: Commands, new_castles: Query<(Entity, &Team), Added<Castle>>) {
+    for (entity, team) in new_castles.iter() {
         let mut castle = commands.entity(entity);
         castle.insert((
             RigidBody::KinematicPositionBased,
@@ -121,7 +118,7 @@ fn process_castle(
             ActiveEvents::COLLISION_EVENTS,
         ));
 
-        let text_color = team_entity.team.get_color();
+        let text_color = team.get_color();
 
         castle.with_children(|builder| {
             builder.spawn((
@@ -134,7 +131,7 @@ fn process_castle(
             builder.spawn(Text2dBundle {
                 text: Text {
                     sections: vec![TextSection::new(
-                        team_entity.team.to_string(),
+                        team.to_string(),
                         TextStyle {
                             color: text_color,
                             ..Default::default()

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,4 +1,4 @@
-use crate::teams::TeamEntity;
+use crate::teams::Team;
 use bevy::prelude::PostUpdate;
 use bevy::prelude::*;
 use bevy_ecs_ldtk::prelude::LdtkFields;
@@ -37,7 +37,7 @@ impl Health {
 // --- Systems ---
 
 /// Should run after attack_system.
-fn check_death(mut commands: Commands, query: Query<(Entity, &Health), With<TeamEntity>>) {
+fn check_death(mut commands: Commands, query: Query<(Entity, &Health), With<Team>>) {
     for (entity, health) in query.iter() {
         if health.health <= 0 {
             commands.entity(entity).despawn_recursive();

--- a/src/inspector_plugin.rs
+++ b/src/inspector_plugin.rs
@@ -1,6 +1,6 @@
 use crate::health::Health;
 use crate::movement::{MoveTarget, MoveToPoint};
-use crate::teams::TeamEntity;
+use crate::teams::Team;
 use crate::waypoints::{IsStartPoint, Waypoint};
 use bevy::app::{App, Plugin};
 use bevy::input::common_conditions::input_toggle_active;
@@ -14,7 +14,7 @@ impl Plugin for InspectorPlugin {
         app.add_plugins(
             WorldInspectorPlugin::default().run_if(input_toggle_active(true, KeyCode::Escape)),
         )
-        .register_type::<TeamEntity>()
+        .register_type::<Team>()
         .register_type::<IsStartPoint>()
         .register_type::<Waypoint>()
         .register_type::<Health>()

--- a/src/inspector_plugin.rs
+++ b/src/inspector_plugin.rs
@@ -1,24 +1,31 @@
 use crate::health::Health;
-use crate::movement::{MoveTarget, MoveToPoint};
+use crate::movement::{MoveTarget, MoveToPoint, WaypointFollower};
 use crate::teams::Team;
-use crate::waypoints::{IsStartPoint, Waypoint};
+use crate::vision::{InVision, VisionRange};
+use crate::waypoints::{IsStartPoint, Waypoint, WaypointMap};
 use bevy::app::{App, Plugin};
 use bevy::input::common_conditions::input_toggle_active;
 use bevy::prelude::KeyCode;
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_inspector_egui::quick::{ResourceInspectorPlugin, WorldInspectorPlugin};
 
 pub struct InspectorPlugin;
 
 impl Plugin for InspectorPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(
+        app.add_plugins((
             WorldInspectorPlugin::default().run_if(input_toggle_active(true, KeyCode::Escape)),
-        )
+            ResourceInspectorPlugin::<WaypointMap>::default()
+                .run_if(input_toggle_active(true, KeyCode::Escape)),
+        ))
+        // Types.
         .register_type::<Team>()
         .register_type::<IsStartPoint>()
         .register_type::<Waypoint>()
+        .register_type::<WaypointFollower>()
         .register_type::<Health>()
         .register_type::<MoveTarget>()
-        .register_type::<MoveToPoint>();
+        .register_type::<MoveToPoint>()
+        .register_type::<VisionRange>()
+        .register_type::<InVision>();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use bevy_castle_fight::inspector_plugin::InspectorPlugin;
 use bevy_castle_fight::movement::MovementPlugin;
 use bevy_castle_fight::resources::ResourcesPlugin;
 use bevy_castle_fight::unit_spawning::UnitSpawningPlugin;
+use bevy_castle_fight::vision::VisionPlugin;
 use bevy_castle_fight::waypoints::WaypointPlugin;
 
 fn main() {
@@ -43,6 +44,7 @@ fn main() {
             ResourcesPlugin,
             CameraPlugin,
             WaypointPlugin,
+            VisionPlugin,
             AttackPlugin,
             HealthPlugin,
             MovementPlugin,

--- a/src/movement.rs
+++ b/src/movement.rs
@@ -28,7 +28,7 @@ pub struct MovementSpeed(pub f32);
 #[derive(Component)]
 pub struct OpponentFollower;
 
-#[derive(Component)]
+#[derive(Component, Reflect)]
 pub struct WaypointFollower {
     pub waypoint: Entity,
 }
@@ -54,7 +54,7 @@ fn move_towards_point(
         // Move towards the target.
         let move_direction = direction.normalize();
         let move_amount = (move_direction.xy() * movement_speed.0 * time.delta_seconds())
-            .clamp_length_max(direction.length())
+            // .clamp_length_max(direction.length())
             .extend(0.);
         transform.translation += move_amount;
         // Remove the move to point.
@@ -107,7 +107,7 @@ fn sync_waypoint_move_target(
                         let direction = waypoint_transform.translation - transform.translation;
                         let distance = direction.length();
 
-                        if distance < 32.0 {
+                        if distance < 64.0 {
                             // Check if there is a next waypoint.
                             if let Some(next_waypoint) = waypoint.next_waypoint {
                                 waypoint_follower.waypoint = next_waypoint;

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -48,3 +48,28 @@ impl Team {
         }
     }
 }
+
+// --- Components ---
+
+/// Team association is used, when an entity is not directly part of a team (for instance waypoints),
+/// but is associated with a team. This allows systems to make
+/// a distinction between active team members and associated entities.
+#[derive(Component, Reflect)]
+pub struct TeamAssociation(pub Team);
+
+impl TeamAssociation {
+    pub fn from_field(entity_instance: &EntityInstance) -> TeamAssociation {
+        let team_field = entity_instance
+            .get_enum_field("team")
+            .expect("Team enum wasn't found on the LDTK entity...");
+
+        TeamAssociation(match team_field.as_str() {
+            "GAIA" => Team::Gaia,
+            "RED" => Team::Red,
+            "BLUE" => Team::Blue,
+            _ => {
+                panic!("Team {:?} doesn't exist!", team_field);
+            }
+        })
+    }
+}

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -6,7 +6,7 @@ use std::fmt::Formatter;
 
 // --- Enums ---
 
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Reflect, Hash, Default)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Reflect, Hash, Default, Component)]
 pub enum Team {
     #[default]
     Gaia,
@@ -32,29 +32,19 @@ impl Team {
             Team::Blue => Color::BLUE,
         }
     }
-}
 
-// --- Components ---
-
-#[derive(Default, Component, Debug, Reflect)]
-pub struct TeamEntity {
-    pub team: Team,
-}
-
-impl TeamEntity {
-    pub fn from_field(entity_instance: &EntityInstance) -> TeamEntity {
+    pub fn from_field(entity_instance: &EntityInstance) -> Team {
         let team_field = entity_instance
             .get_enum_field("team")
             .expect("Team enum wasn't found on the LDTK entity...");
-        TeamEntity {
-            team: match team_field.as_str() {
-                "GAIA" => Team::Gaia,
-                "RED" => Team::Red,
-                "BLUE" => Team::Blue,
-                _ => {
-                    panic!("Team {:?} doesn't exist!", team_field);
-                }
-            },
+
+        match team_field.as_str() {
+            "GAIA" => Team::Gaia,
+            "RED" => Team::Red,
+            "BLUE" => Team::Blue,
+            _ => {
+                panic!("Team {:?} doesn't exist!", team_field);
+            }
         }
     }
 }

--- a/src/unit_spawning.rs
+++ b/src/unit_spawning.rs
@@ -1,4 +1,4 @@
-use crate::teams::TeamEntity;
+use crate::teams::Team;
 use crate::units::spawn_unit;
 use crate::waypoints::WaypointMap;
 use bevy::prelude::*;
@@ -28,15 +28,15 @@ fn unit_spawner_spawn_units(
     asset_server: Res<AssetServer>,
     waypoint_map: Res<WaypointMap>,
     time: Res<Time>,
-    mut query: Query<(&mut UnitSpawner, &Transform, &TeamEntity)>,
+    mut query: Query<(&mut UnitSpawner, &Transform, &Team)>,
 ) {
-    for (mut unit_spawner, transform, unit) in query.iter_mut() {
+    for (mut unit_spawner, transform, team) in query.iter_mut() {
         if unit_spawner.time_left > 0. {
             unit_spawner.time_left -= time.delta_seconds()
         } else {
             spawn_unit(
                 &mut commands,
-                unit.team,
+                *team,
                 asset_server.load("prototype-unit.png"),
                 transform.translation.x,
                 transform.translation.y,

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,7 +1,7 @@
 use crate::attack::AttackStats;
 use crate::health::Health;
 use crate::movement::{MovementSpeed, OpponentFollower, WaypointFollower};
-use crate::teams::{Team, TeamEntity};
+use crate::teams::Team;
 use crate::waypoints::WaypointMap;
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
@@ -22,7 +22,7 @@ pub fn spawn_unit(
     waypoint_map: &Res<WaypointMap>,
 ) {
     let mut unit_entity = commands.spawn((
-        TeamEntity { team },
+        team,
         Unit,
         OpponentFollower,
         Health {

--- a/src/units.rs
+++ b/src/units.rs
@@ -2,6 +2,7 @@ use crate::attack::AttackStats;
 use crate::health::Health;
 use crate::movement::{MovementSpeed, OpponentFollower, WaypointFollower};
 use crate::teams::Team;
+use crate::vision::{InVision, Visible, VisionRange};
 use crate::waypoints::WaypointMap;
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
@@ -24,6 +25,12 @@ pub fn spawn_unit(
     let mut unit_entity = commands.spawn((
         team,
         Unit,
+        Visible,
+        VisionRange(32. * 4.),
+        InVision {
+            friendlies: vec![],
+            enemies: vec![],
+        },
         OpponentFollower,
         Health {
             health: 5,
@@ -42,21 +49,11 @@ pub fn spawn_unit(
             ..Default::default()
         },
         RigidBody::KinematicPositionBased,
-        Collider::ball(32. * 3.), // Vision sensor.
-        Sensor,
-        CollisionGroups::new(Group::GROUP_2, Group::GROUP_1),
-        ActiveCollisionTypes::all(), // TODO: Optimize later.
-        ActiveEvents::COLLISION_EVENTS,
+        Collider::ball(20.), // Actual collider matching sprite size.
     ));
+    unit_entity.insert(Name::new("Unit"));
 
     let text_color = team.get_color();
-
-    unit_entity.with_children(|builder| {
-        builder.spawn((
-            Collider::ball(20.), // Actual collider matching sprite size.
-            CollisionGroups::new(Group::GROUP_1, Group::GROUP_2),
-        ));
-    });
 
     unit_entity.with_children(|builder| {
         builder.spawn(Text2dBundle {

--- a/src/vision.rs
+++ b/src/vision.rs
@@ -1,7 +1,7 @@
 use crate::attack::{AttackStats, AttackTarget};
 use crate::health::Health;
 use crate::movement::MoveTarget;
-use crate::teams::TeamEntity;
+use crate::teams::Team;
 use bevy::prelude::*;
 use bevy_rapier2d::geometry::Sensor;
 use bevy_rapier2d::pipeline::CollisionEvent;
@@ -31,8 +31,8 @@ pub struct VisionRange(f32);
 fn vision_detect_target(
     mut commands: Commands,
     mut collisions: EventReader<CollisionEvent>,
-    attack_query: Query<(Entity, &TeamEntity), (With<AttackStats>, Without<AttackTarget>)>,
-    defend_query: Query<(Entity, &TeamEntity), With<Health>>,
+    attack_query: Query<(Entity, &Team), (With<AttackStats>, Without<AttackTarget>)>,
+    defend_query: Query<(Entity, &Team), With<Health>>,
     attack_target_query: Query<(Entity, &AttackTarget, Option<&MoveTarget>)>,
     sensor_query: Query<&Sensor>,
     parent_query: Query<&Parent>,
@@ -55,7 +55,7 @@ fn vision_detect_target(
     let check_set_target = |entity1: &Entity, entity2: &Entity, commands: &mut Commands| {
         if let Ok((attacker_entity, attacker_team)) = attack_query.get(*entity1) {
             if let Ok((defender_entity, defender_team)) = defend_query.get(*entity2) {
-                if attacker_team.team != defender_team.team {
+                if attacker_team != defender_team {
                     commands
                         .entity(attacker_entity)
                         .insert(AttackTarget(defender_entity));

--- a/src/waypoints.rs
+++ b/src/waypoints.rs
@@ -20,12 +20,11 @@ impl Plugin for WaypointPlugin {
 
 #[derive(Component, Reflect)]
 pub struct Waypoint {
-    pub id: Option<String>,
     pub next_waypoint: Option<Entity>,
 }
 
 /// The waypoint map is used to find the closest starting waypoint for each team.
-#[derive(Resource)]
+#[derive(Resource, Reflect, Default)]
 pub struct WaypointMap {
     pub start_point_waypoints: HashMap<Team, Vec<(Entity, Vec2)>>,
 }
@@ -61,10 +60,14 @@ impl IsStartPoint {
 }
 
 fn add_start_waypoints_to_resources(
-    query: Query<(Entity, &Team, &Transform), Added<Waypoint>>,
+    query: Query<(Entity, &Team, &Transform, &IsStartPoint), Added<Waypoint>>,
     mut waypoint_map: ResMut<WaypointMap>,
 ) {
-    for (new_entity, team, transform) in query.iter() {
+    for (new_entity, team, transform, is_starting_point) in query.iter() {
+        if !is_starting_point.0 {
+            continue;
+        }
+
         let team_waypoint_list = waypoint_map
             .start_point_waypoints
             .entry(*team)

--- a/src/waypoints.rs
+++ b/src/waypoints.rs
@@ -1,4 +1,4 @@
-use crate::teams::Team;
+use crate::teams::{Team, TeamAssociation};
 use bevy::prelude::*;
 use bevy::utils::HashMap;
 use bevy_ecs_ldtk::prelude::*;
@@ -60,17 +60,17 @@ impl IsStartPoint {
 }
 
 fn add_start_waypoints_to_resources(
-    query: Query<(Entity, &Team, &Transform, &IsStartPoint), Added<Waypoint>>,
+    query: Query<(Entity, &TeamAssociation, &Transform, &IsStartPoint), Added<Waypoint>>,
     mut waypoint_map: ResMut<WaypointMap>,
 ) {
-    for (new_entity, team, transform, is_starting_point) in query.iter() {
+    for (new_entity, team_association, transform, is_starting_point) in query.iter() {
         if !is_starting_point.0 {
             continue;
         }
 
         let team_waypoint_list = waypoint_map
             .start_point_waypoints
-            .entry(*team)
+            .entry(team_association.0)
             .or_insert(Vec::new());
         team_waypoint_list.push((new_entity, transform.translation.xy()));
     }

--- a/src/waypoints.rs
+++ b/src/waypoints.rs
@@ -1,4 +1,4 @@
-use crate::teams::{Team, TeamEntity};
+use crate::teams::Team;
 use bevy::prelude::*;
 use bevy::utils::HashMap;
 use bevy_ecs_ldtk::prelude::*;
@@ -61,13 +61,13 @@ impl IsStartPoint {
 }
 
 fn add_start_waypoints_to_resources(
-    query: Query<(Entity, &TeamEntity, &Transform), Added<Waypoint>>,
+    query: Query<(Entity, &Team, &Transform), Added<Waypoint>>,
     mut waypoint_map: ResMut<WaypointMap>,
 ) {
-    for (new_entity, team_entity, transform) in query.iter() {
+    for (new_entity, team, transform) in query.iter() {
         let team_waypoint_list = waypoint_map
             .start_point_waypoints
-            .entry(team_entity.team)
+            .entry(*team)
             .or_insert(Vec::new());
         team_waypoint_list.push((new_entity, transform.translation.xy()));
     }


### PR DESCRIPTION
Vision is now using KD-trees. New InVision component contains lists of nearby friendlies and enemies based on vision range.

Also the Team enum is used as a component directly instead of using the TeamEntity struct (which has now been removed).

Entities with the VisionRange and InVision components will now have lists created for friendlies and enemies.
For enemies, entities that don't have the Visible component attached will be skipped. Can for instance be used for invisible enemies.

Closes #2 