### PR TITLE
Only run build & test on PR

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,8 +1,6 @@
 name: Build and Test
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
If we all start pushing branches, my free use of build pipelines will finish quick. So lets just do on PRs.