### PR TITLE
21 make use of loaded factions

### DIFF
--- a/assets/faction-assets/human_b_archery-range_icon.png
+++ b/assets/faction-assets/human_b_archery-range_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7c8181a49cb743910797843763cbeaaf40e74d84e8e5dc3cf634e27c6b44a9c
+size 61485

--- a/assets/faction-assets/human_b_barracks_icon.png
+++ b/assets/faction-assets/human_b_barracks_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d1841a39363d55e405a7611259144627757e1805c46c932db93090a6fdac5c4
+size 59456

--- a/assets/faction-assets/human_b_fire-mage-tower_icon.png
+++ b/assets/faction-assets/human_b_fire-mage-tower_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:429929e9451fa54353097ef06aa66643d42d108b967b3a30307da0c14fa2c547
+size 77754

--- a/assets/faction-assets/human_b_siege-workshop_icon.png
+++ b/assets/faction-assets/human_b_siege-workshop_icon.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:93569ff86693e06fbf89ff31987b3a20a99d9b1da3f8d70d6bef6e1278692433
+size 59423

--- a/assets/factions/humans.faction.json
+++ b/assets/factions/humans.faction.json
@@ -6,6 +6,7 @@
       "id": "human_b_barracks",
       "name": "Barracks",
       "sprite": "faction-assets/human_b_barracks.png",
+      "icon": "faction-assets/human_b_barracks_icon.png",
       "components": [
         {
           "Health": {
@@ -25,6 +26,7 @@
       "id": "human_b_archery-range",
       "name": "Archery Range",
       "sprite": "faction-assets/human_b_archery-range.png",
+      "icon": "faction-assets/human_b_archery-range_icon.png",
       "components": [
         {
           "Health": {
@@ -44,6 +46,7 @@
       "id": "human_b_fire-mage-tower",
       "name": "Fire Mage Tower",
       "sprite": "faction-assets/human_b_fire-mage-tower.png",
+      "icon": "faction-assets/human_b_fire-mage-tower_icon.png",
       "components": [
         {
           "Health": {
@@ -63,6 +66,7 @@
       "id": "human_b_siege-workshop",
       "name": "Siege Workshop",
       "sprite": "faction-assets/human_b_siege-workshop.png",
+      "icon": "faction-assets/human_b_siege-workshop_icon.png",
       "components": [
         {
           "Health": {

--- a/assets/factions/humans.faction.json
+++ b/assets/factions/humans.faction.json
@@ -106,7 +106,10 @@
         {
           "MovementSpeed": 96
         },
-        "Visible"
+        "Visible",
+        {
+          "VisionRange": 80.0
+        }
       ]
     },
     {
@@ -131,7 +134,10 @@
         {
           "MovementSpeed": 96
         },
-        "Visible"
+        "Visible",
+        {
+          "VisionRange": 96.0
+        }
       ]
     },
     {
@@ -156,7 +162,10 @@
         {
           "MovementSpeed": 80
         },
-        "Visible"
+        "Visible",
+        {
+          "VisionRange": 80.0
+        }
       ]
     },
     {
@@ -181,7 +190,10 @@
         {
           "MovementSpeed": 64
         },
-        "Visible"
+        "Visible",
+        {
+          "VisionRange": 80.0
+        }
       ]
     }
   ]

--- a/src/game/buildings.rs
+++ b/src/game/buildings.rs
@@ -1,10 +1,11 @@
-use crate::game::health::Health;
-use crate::game::teams::Team;
-use crate::game::unit_spawning::UnitSpawner;
-use crate::game::vision::Visible;
-use crate::game::InGameTag;
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
+
+use crate::game::spawning::add_blueprint_components;
+use crate::game::teams::Team;
+use crate::game::InGameTag;
+use crate::load_game::load_factions::BuildingBlueprint;
+use crate::resources::PlayerSettings;
 
 // --- Components ---
 
@@ -18,33 +19,43 @@ pub struct Castle;
 pub struct BuildingGhost {
     pub placement_valid: bool,
     pub team: Team,
+    pub building_blueprint: BuildingBlueprint,
 }
 
 // --- Helper functions ---
 
 /// Helper function to spawn a building. This is not a system.
-pub fn spawn_building(commands: &mut Commands, team: Team, x: f32, y: f32, sprite: Handle<Image>) {
+pub fn spawn_building(
+    commands: &mut Commands,
+    team: Team,
+    x: f32,
+    y: f32,
+    building_blueprint: BuildingBlueprint,
+    player_settings: &Res<PlayerSettings>,
+) {
     let mut building_entity = commands.spawn((
         InGameTag,
         team,
         Building,
-        Visible,
-        Health {
-            health: 10,
-            max_health: 10,
-        },
         SpriteBundle {
-            texture: sprite,
+            texture: building_blueprint.sprite.clone(),
             transform: Transform::from_xyz(x, y, 10.),
             ..Default::default()
-        },
-        UnitSpawner {
-            spawn_time: 5.0,
-            time_left: 5.0,
         },
         RigidBody::KinematicPositionBased,
         Collider::cuboid(32.0, 32.0), // Actual collider matching sprite size.
     ));
+    building_entity.insert(Name::new(format!(
+        "Building: {} - Team: {}",
+        building_blueprint.name, team
+    )));
+
+    // Insert components from the blueprint.
+    add_blueprint_components(
+        &mut building_entity,
+        &building_blueprint.components,
+        player_settings,
+    );
 
     let text_color = team.get_color();
 
@@ -72,16 +83,17 @@ pub fn spawn_ghost_building(
     team: Team,
     x: f32,
     y: f32,
-    sprite: Handle<Image>,
+    building_blueprint: BuildingBlueprint,
 ) {
     commands.spawn((
         InGameTag,
         BuildingGhost {
             placement_valid: true,
             team,
+            building_blueprint: building_blueprint.clone(),
         },
         SpriteBundle {
-            texture: sprite,
+            texture: building_blueprint.sprite.clone(),
             transform: Transform::from_xyz(x, y, 10.1),
             sprite: Sprite {
                 color: Color::rgba(0.5, 1.0, 0.5, 0.7),

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -15,6 +15,7 @@ use unit_spawning::UnitSpawningPlugin;
 use vision::VisionPlugin;
 use waypoints::WaypointPlugin;
 
+use crate::game::ui::UiPlugin;
 use crate::AppState;
 
 //mod
@@ -29,6 +30,7 @@ pub mod movement;
 mod resources;
 mod systems;
 pub mod teams;
+mod ui;
 mod unit_spawning;
 mod units;
 pub mod vision;
@@ -44,6 +46,9 @@ impl Plugin for GamePlugin {
             },
             ResourcesPlugin,
             CameraPlugin,
+            UiPlugin {
+                state: AppState::Game,
+            },
             WaypointPlugin {
                 state: AppState::Game,
             },

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -28,6 +28,7 @@ mod grid_traits;
 pub mod health;
 pub mod movement;
 mod resources;
+mod spawning;
 mod systems;
 pub mod teams;
 mod ui;

--- a/src/game/spawning.rs
+++ b/src/game/spawning.rs
@@ -1,0 +1,66 @@
+use bevy::ecs::system::EntityCommands;
+use bevy::prelude::Res;
+
+use crate::game::attack::AttackStats;
+use crate::game::health::Health;
+use crate::game::movement::{MovementSpeed, OpponentFollower};
+use crate::game::unit_spawning::UnitSpawner;
+use crate::game::vision::{InVision, Visible, VisionRange};
+use crate::load_game::load_factions::ComponentBlueprint;
+use crate::resources::PlayerSettings;
+
+pub fn add_blueprint_components(
+    entity_commands: &mut EntityCommands,
+    component_blueprints: &Vec<ComponentBlueprint>,
+    player_settings: &Res<PlayerSettings>,
+) {
+    for component_blueprint in component_blueprints.iter() {
+        match component_blueprint {
+            ComponentBlueprint::Health { max_health, health } => {
+                entity_commands.insert(Health {
+                    health: *health,
+                    max_health: *max_health,
+                });
+            }
+            ComponentBlueprint::Visible => {
+                entity_commands.insert(Visible);
+            }
+            ComponentBlueprint::OpponentFollower => {
+                entity_commands.insert(OpponentFollower);
+            }
+            ComponentBlueprint::MovementSpeed(speed) => {
+                entity_commands.insert(MovementSpeed((*speed) as f32));
+            }
+            ComponentBlueprint::AttackStats {
+                damage,
+                attack_speed,
+                attack_range,
+            } => {
+                entity_commands.insert(AttackStats {
+                    damage: *damage,
+                    attack_speed: *attack_speed,
+                    attack_range: *attack_range as f32,
+                    time_till_next_attack: 0.,
+                });
+            }
+            ComponentBlueprint::UnitSpawner {
+                unit_id,
+                spawn_time,
+            } => {
+                entity_commands.insert(UnitSpawner {
+                    spawn_time: *spawn_time,
+                    time_left: *spawn_time,
+                    unit_blueprint: player_settings.faction.units[unit_id].clone(),
+                });
+            }
+            ComponentBlueprint::VisionRange(range) => {
+                entity_commands.insert(VisionRange(*range));
+                // For vision to work, the InVision component must be present too.
+                entity_commands.insert(InVision {
+                    friendlies: vec![],
+                    enemies: vec![],
+                });
+            }
+        }
+    }
+}

--- a/src/game/spawning.rs
+++ b/src/game/spawning.rs
@@ -11,7 +11,7 @@ use crate::resources::PlayerSettings;
 
 pub fn add_blueprint_components(
     entity_commands: &mut EntityCommands,
-    component_blueprints: &Vec<ComponentBlueprint>,
+    component_blueprints: &[ComponentBlueprint],
     player_settings: &Res<PlayerSettings>,
 ) {
     for component_blueprint in component_blueprints.iter() {

--- a/src/game/spawning.rs
+++ b/src/game/spawning.rs
@@ -1,5 +1,7 @@
+use std::time::Duration;
+
 use bevy::ecs::system::EntityCommands;
-use bevy::prelude::Res;
+use bevy::prelude::*;
 
 use crate::game::attack::AttackStats;
 use crate::game::health::Health;
@@ -40,7 +42,7 @@ pub fn add_blueprint_components(
                     damage: *damage,
                     attack_speed: *attack_speed,
                     attack_range: *attack_range as f32,
-                    time_till_next_attack: 0.,
+                    time_till_next_attack: Timer::new(Duration::from_secs(0), TimerMode::Once),
                 });
             }
             ComponentBlueprint::UnitSpawner {

--- a/src/game/ui.rs
+++ b/src/game/ui.rs
@@ -74,11 +74,11 @@ fn setup_ui(mut commands: Commands, selected_faction: Res<SelectedFaction>) {
                                 // Set a height and the aspect ratio to be 1:1, so it will auto set the width
                                 // to be equal to the height.
                                 height: Val::Percent(30.),
-                                aspect_ratio: Some(1.0),
+                                aspect_ratio: Some(1.25),
                                 // Set the grid to have 4 columns.
                                 grid_template_columns: RepeatedGridTrack::flex(4, 1.0),
                                 // Set the grid to have 4 rows.
-                                grid_template_rows: RepeatedGridTrack::flex(4, 1.0),
+                                grid_template_rows: RepeatedGridTrack::flex(3, 1.0),
                                 // Set a gap between each cell.
                                 row_gap: Val::Px(12.),
                                 column_gap: Val::Px(12.),

--- a/src/game/ui.rs
+++ b/src/game/ui.rs
@@ -1,0 +1,152 @@
+// --- Plugin ---
+
+use bevy::prelude::*;
+
+use crate::game::InGameTag;
+use crate::load_game::load_factions::BuildingBlueprint;
+use crate::resources::SelectedFaction;
+
+pub struct UiPlugin<S: States> {
+    pub state: S,
+}
+
+impl<S: States> Plugin for UiPlugin<S> {
+    fn build(&self, app: &mut App) {
+        app.add_systems(OnEnter(self.state.clone()), setup_ui)
+            .add_systems(
+                Update,
+                building_btn_interactions.run_if(in_state(self.state.clone())),
+            );
+    }
+}
+
+// --- Components ---
+
+#[derive(Component)]
+struct BtnBuilding;
+#[derive(Component)]
+struct BtnBuildingImage;
+
+// --- Systems ---
+
+fn setup_ui(mut commands: Commands, selected_faction: Res<SelectedFaction>) {
+    // Layout.
+    commands
+        .spawn((
+            InGameTag, // Adding this tag, means it will be cleaned up, when exiting the "Game" app state.
+            NodeBundle {
+                style: Style {
+                    width: Val::Percent(100.),
+                    height: Val::Percent(100.),
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    justify_content: JustifyContent::SpaceBetween,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ))
+        .with_children(|layout| {
+            // Top UI bar.
+            layout.spawn(NodeBundle {
+                ..Default::default()
+            });
+            // Bottom UI bar.
+            layout
+                .spawn(NodeBundle {
+                    style: Style {
+                        display: Display::Flex,
+                        flex_direction: FlexDirection::Row,
+                        justify_content: JustifyContent::SpaceBetween,
+                        align_items: AlignItems::End,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .with_children(|bottom_bar| {
+                    // Building menu.
+                    bottom_bar
+                        .spawn(NodeBundle {
+                            style: Style {
+                                display: Display::Grid,
+                                // Add padding around the grid.
+                                padding: UiRect::all(Val::Px(12.)),
+                                // Set a height and the aspect ratio to be 1:1, so it will auto set the width
+                                // to be equal to the height.
+                                height: Val::Percent(30.),
+                                aspect_ratio: Some(1.0),
+                                // Set the grid to have 4 columns.
+                                grid_template_columns: RepeatedGridTrack::flex(4, 1.0),
+                                // Set the grid to have 4 rows.
+                                grid_template_rows: RepeatedGridTrack::flex(4, 1.0),
+                                // Set a gap between each cell.
+                                row_gap: Val::Px(12.),
+                                column_gap: Val::Px(12.),
+                                ..Default::default()
+                            },
+                            background_color: BackgroundColor(Color::rgba(0., 0., 0., 0.5)),
+                            ..Default::default()
+                        })
+                        .with_children(|building_menu| {
+                            for building in &selected_faction.0.buildings {
+                                spawn_building_btn(building_menu, building);
+                            }
+                        });
+                });
+        });
+}
+
+fn building_btn_interactions(
+    query: Query<(&Interaction, &Children), (Changed<Interaction>, With<BtnBuilding>)>,
+    mut image_query: Query<&mut BackgroundColor>,
+) {
+    for (interaction, children) in &query {
+        let mut image_bg_color = image_query.get_mut(children[0]).unwrap();
+        match *interaction {
+            // Interaction::Pressed => {
+            //     text.sections[0].value = "Press".to_string();
+            //     *color = PRESSED_BUTTON.into();
+            //     border_color.0 = Color::RED;
+            // }
+            Interaction::Hovered => {
+                *image_bg_color = Color::rgba(1., 1., 1., 0.5).into();
+            }
+            Interaction::None => {
+                *image_bg_color = Color::WHITE.into();
+            }
+            _ => {}
+        }
+    }
+}
+
+// --- Helper functions ---
+
+fn spawn_building_btn(builder: &mut ChildBuilder, building_blueprint: &BuildingBlueprint) {
+    builder
+        .spawn((
+            BtnBuilding,
+            ButtonBundle {
+                style: Style {
+                    width: Val::Percent(100.),
+                    height: Val::Percent(100.),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ))
+        .with_children(|btn| {
+            btn.spawn((
+                BtnBuildingImage,
+                ImageBundle {
+                    image: UiImage::new(building_blueprint.icon.clone()),
+                    style: Style {
+                        width: Val::Percent(100.),
+                        height: Val::Percent(100.),
+                        ..Default::default()
+                    },
+                    background_color: BackgroundColor(Color::WHITE),
+                    ..Default::default()
+                },
+            ));
+        });
+}

--- a/src/game/unit_spawning.rs
+++ b/src/game/unit_spawning.rs
@@ -1,7 +1,10 @@
+use bevy::prelude::*;
+
 use crate::game::teams::Team;
 use crate::game::units::spawn_unit;
 use crate::game::waypoints::WaypointMap;
-use bevy::prelude::*;
+use crate::load_game::load_factions::UnitBlueprint;
+use crate::resources::PlayerSettings;
 
 // --- Plugin ---
 
@@ -24,16 +27,17 @@ impl<S: States> Plugin for UnitSpawningPlugin<S> {
 pub struct UnitSpawner {
     pub spawn_time: f32,
     pub time_left: f32,
+    pub unit_blueprint: UnitBlueprint,
 }
 
 // --- Systems ---
 
 fn unit_spawner_spawn_units(
     mut commands: Commands,
-    asset_server: Res<AssetServer>,
     waypoint_map: Res<WaypointMap>,
     time: Res<Time>,
     mut query: Query<(&mut UnitSpawner, &Transform, &Team)>,
+    player_settings: Res<PlayerSettings>,
 ) {
     for (mut unit_spawner, transform, team) in query.iter_mut() {
         if unit_spawner.time_left > 0. {
@@ -42,10 +46,11 @@ fn unit_spawner_spawn_units(
             spawn_unit(
                 &mut commands,
                 *team,
-                asset_server.load("prototype-unit.png"),
+                unit_spawner.unit_blueprint.clone(),
                 transform.translation.x,
                 transform.translation.y,
                 &waypoint_map,
+                &player_settings,
             );
             unit_spawner.time_left = unit_spawner.spawn_time
         }

--- a/src/inspector_plugin.rs
+++ b/src/inspector_plugin.rs
@@ -1,12 +1,14 @@
+use bevy::app::{App, Plugin};
+use bevy::input::common_conditions::input_toggle_active;
+use bevy::prelude::KeyCode;
+use bevy_inspector_egui::quick::{ResourceInspectorPlugin, WorldInspectorPlugin};
+
 use crate::game::health::Health;
 use crate::game::movement::{MoveTarget, MoveToPoint, WaypointFollower};
 use crate::game::teams::Team;
 use crate::game::vision::{InVision, VisionRange};
 use crate::game::waypoints::{IsStartPoint, Waypoint, WaypointMap};
-use bevy::app::{App, Plugin};
-use bevy::input::common_conditions::input_toggle_active;
-use bevy::prelude::KeyCode;
-use bevy_inspector_egui::quick::{ResourceInspectorPlugin, WorldInspectorPlugin};
+use crate::load_game::load_factions::Factions;
 
 pub struct InspectorPlugin;
 
@@ -15,6 +17,8 @@ impl Plugin for InspectorPlugin {
         app.add_plugins((
             WorldInspectorPlugin::default().run_if(input_toggle_active(true, KeyCode::Escape)),
             ResourceInspectorPlugin::<WaypointMap>::default()
+                .run_if(input_toggle_active(true, KeyCode::Escape)),
+            ResourceInspectorPlugin::<Factions>::default()
                 .run_if(input_toggle_active(true, KeyCode::Escape)),
         ))
         // Types.

--- a/src/load_game/load_factions.rs
+++ b/src/load_game/load_factions.rs
@@ -106,7 +106,7 @@ struct UnitData {
 
 // --- Resource types ---
 
-#[derive(Resource, Debug)]
+#[derive(Resource, Debug, Clone, Reflect)]
 pub struct FactionBlueprint {
     pub id: String,
     pub name: String,
@@ -114,7 +114,7 @@ pub struct FactionBlueprint {
     pub units: Vec<UnitBlueprint>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Reflect)]
 pub struct BuildingBlueprint {
     pub id: String,
     pub name: String,
@@ -123,7 +123,7 @@ pub struct BuildingBlueprint {
     pub components: Vec<ComponentBlueprint>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Reflect)]
 pub struct UnitBlueprint {
     pub id: String,
     pub name: String,
@@ -131,7 +131,7 @@ pub struct UnitBlueprint {
     pub components: Vec<ComponentBlueprint>,
 }
 
-#[derive(Deserialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Debug, PartialEq, Clone, Reflect)]
 pub enum ComponentBlueprint {
     UnitSpawner {
         unit_id: String,
@@ -156,8 +156,8 @@ pub enum ComponentBlueprint {
 #[derive(Resource)]
 struct FactionsFolderHandle(Handle<LoadedFolder>);
 
-#[derive(Resource)]
-struct Factions(Vec<FactionBlueprint>);
+#[derive(Resource, Reflect)]
+pub struct Factions(pub Vec<FactionBlueprint>);
 
 // --- Systems ---
 
@@ -222,7 +222,8 @@ fn setup_factions_resource(
                     faction_blueprints.push(faction_blueprint);
                 }
 
-                commands.insert_resource(Factions(faction_blueprints))
+                commands.insert_resource(Factions(faction_blueprints));
+                info!("Factions resource has been inserted!");
             }
         }
     }
@@ -230,7 +231,6 @@ fn setup_factions_resource(
 
 /// This is a test function to see that it works. When factions are in use, this should be removed.
 fn display_content(
-    mut commands: Commands,
     factions_res: Option<Res<Factions>>,
     mut next_state: ResMut<NextState<AppState>>,
 ) {
@@ -242,7 +242,6 @@ fn display_content(
     for faction in factions.0.iter() {
         info!("FACTION: {:?}", faction);
     }
-    commands.remove_resource::<Factions>();
 
     // Moving to the next state here is temporary.
     next_state.set(AppState::MainMenu);

--- a/src/load_game/load_factions.rs
+++ b/src/load_game/load_factions.rs
@@ -6,6 +6,7 @@ use bevy::app::{App, Plugin};
 use bevy::asset::io::Reader;
 use bevy::asset::*;
 use bevy::prelude::*;
+use bevy::utils::HashMap;
 use serde::Deserialize;
 use serde_json::from_slice;
 use thiserror::Error;
@@ -110,8 +111,8 @@ struct UnitData {
 pub struct FactionBlueprint {
     pub id: String,
     pub name: String,
-    pub buildings: Vec<BuildingBlueprint>,
-    pub units: Vec<UnitBlueprint>,
+    pub buildings: HashMap<String, BuildingBlueprint>,
+    pub units: HashMap<String, UnitBlueprint>,
 }
 
 #[derive(Debug, Clone, Reflect)]
@@ -146,6 +147,7 @@ pub enum ComponentBlueprint {
         attack_speed: f32,
         attack_range: i32,
     },
+    VisionRange(f32),
     OpponentFollower,
     MovementSpeed(i32),
     Visible,
@@ -199,22 +201,32 @@ fn setup_factions_resource(
                         buildings: faction
                             .buildings
                             .iter()
-                            .map(|building_asset| BuildingBlueprint {
-                                id: building_asset.id.clone(),
-                                name: building_asset.name.clone(),
-                                sprite: asset_server.load(&building_asset.sprite),
-                                icon: asset_server.load(&building_asset.icon),
-                                components: building_asset.components.clone(),
+                            .map(|building_asset| {
+                                (
+                                    building_asset.id.clone(),
+                                    BuildingBlueprint {
+                                        id: building_asset.id.clone(),
+                                        name: building_asset.name.clone(),
+                                        sprite: asset_server.load(&building_asset.sprite),
+                                        icon: asset_server.load(&building_asset.icon),
+                                        components: building_asset.components.clone(),
+                                    },
+                                )
                             })
                             .collect(),
                         units: faction
                             .units
                             .iter()
-                            .map(|unit_asset| UnitBlueprint {
-                                id: unit_asset.id.clone(),
-                                name: unit_asset.name.clone(),
-                                sprite: asset_server.load(&unit_asset.sprite),
-                                components: unit_asset.components.clone(),
+                            .map(|unit_asset| {
+                                (
+                                    unit_asset.id.clone(),
+                                    UnitBlueprint {
+                                        id: unit_asset.id.clone(),
+                                        name: unit_asset.name.clone(),
+                                        sprite: asset_server.load(&unit_asset.sprite),
+                                        components: unit_asset.components.clone(),
+                                    },
+                                )
                             })
                             .collect(),
                     };

--- a/src/load_game/load_factions.rs
+++ b/src/load_game/load_factions.rs
@@ -92,6 +92,7 @@ struct BuildingData {
     id: String,
     name: String,
     sprite: String,
+    icon: String,
     components: Vec<ComponentBlueprint>,
 }
 
@@ -118,6 +119,7 @@ pub struct BuildingBlueprint {
     pub id: String,
     pub name: String,
     pub sprite: Handle<Image>,
+    pub icon: Handle<Image>,
     pub components: Vec<ComponentBlueprint>,
 }
 
@@ -201,6 +203,7 @@ fn setup_factions_resource(
                                 id: building_asset.id.clone(),
                                 name: building_asset.name.clone(),
                                 sprite: asset_server.load(&building_asset.sprite),
+                                icon: asset_server.load(&building_asset.icon),
                                 components: building_asset.components.clone(),
                             })
                             .collect(),
@@ -242,6 +245,6 @@ fn display_content(
     commands.remove_resource::<Factions>();
 
     // Moving to the next state here is temporary.
-    next_state.set(AppState::Game);
-    println!("Entered Game State")
+    next_state.set(AppState::MainMenu);
+    println!("Entered Main Menu")
 }

--- a/src/load_game/mod.rs
+++ b/src/load_game/mod.rs
@@ -4,7 +4,7 @@ use crate::load_game::load_factions::FactionLoaderPlugin;
 use crate::load_game::LoadingSet::{LoadStartup, LoadUpdate};
 use crate::AppState;
 
-mod load_factions;
+pub mod load_factions;
 
 pub struct LoadGamePlugin;
 

--- a/src/load_game/mod.rs
+++ b/src/load_game/mod.rs
@@ -23,7 +23,7 @@ impl Plugin for LoadGamePlugin {
             .add_plugins(FactionLoaderPlugin)
             // Third party plugins.
             // Third party resources
-            //State Transitions
+            // State Transitions
             // Systems
             .add_systems(Update, apply_deferred.after(LoadStartup).before(LoadUpdate));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod game;
 mod inspector_plugin;
 mod load_game;
 mod main_menu;
+mod resources;
 mod systems;
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,12 @@ use bevy::{
     render::{settings::WgpuSettings, RenderPlugin},
 };
 
-use crate::load_game::LoadGamePlugin;
 use game::GamePlugin;
 use inspector_plugin::InspectorPlugin;
 use main_menu::MainMenuPlugin;
 use systems::*;
+
+use crate::load_game::LoadGamePlugin;
 
 mod game;
 mod inspector_plugin;
@@ -27,7 +28,7 @@ fn main() {
             synchronous_pipeline_compilation: false,
         }),))
         //States
-        .insert_state(AppState::MainMenu)
+        .insert_state(AppState::LoadGameAssets)
         //State transitions
         // Debug plugins.
         .add_plugins(InspectorPlugin)
@@ -43,7 +44,7 @@ fn main() {
 #[derive(States, Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum AppState {
     #[default]
-    MainMenu,
     LoadGameAssets,
+    MainMenu,
     Game,
 }

--- a/src/main_menu/init_screen.rs
+++ b/src/main_menu/init_screen.rs
@@ -16,7 +16,7 @@ impl<S: States> Plugin for InitScreenPlugin<S> {
         app.add_systems(OnEnter(self.state.clone()), spawn_ui)
             .add_systems(
                 Update,
-                btn_play_interaction.run_if(in_state(self.state.clone())),
+                (btn_interaction_handler, btn_action_handler).run_if(in_state(self.state.clone())),
             );
     }
 }
@@ -32,8 +32,15 @@ const PRESSED_BUTTON: Color = Color::rgba(1., 1., 1., 0.5);
 #[derive(Component)]
 struct Label;
 
+#[derive(PartialEq)]
+enum ButtonAction {
+    Play,
+}
+
 #[derive(Component)]
-struct Button;
+struct MenuButton {
+    action: ButtonAction,
+}
 
 #[derive(Component)]
 struct BtnPlay;
@@ -77,8 +84,9 @@ fn spawn_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
             // Spawn button.
             builder
                 .spawn((
-                    Button,
-                    BtnPlay,
+                    MenuButton {
+                        action: ButtonAction::Play,
+                    },
                     ButtonBundle {
                         style: Style {
                             width: Val::Px(300.),
@@ -107,26 +115,40 @@ fn spawn_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
-fn btn_play_interaction(
+fn btn_action_handler(
     mut commands: Commands,
-    mut query: Query<(&Interaction, &mut BackgroundColor), With<BtnPlay>>,
+    query: Query<(&Interaction, &MenuButton), Changed<Interaction>>,
     mut next_state: ResMut<NextState<AppState>>,
     loaded_factions: Option<Res<Factions>>,
 ) {
-    for (interaction, mut bg_colour) in &mut query {
+    for (interaction, menu_button) in query.iter() {
+        match *interaction {
+            Interaction::Pressed => match menu_button.action {
+                ButtonAction::Play => {
+                    if let Some(factions) = &loaded_factions {
+                        if let Some(selected_faction) = factions.0.first().cloned() {
+                            commands.insert_resource(SelectedFaction(selected_faction));
+                            next_state.set(AppState::Game)
+                        } else {
+                            error!("Couldn't get a faction from loaded factions to set as the selected faction.")
+                        }
+                    } else {
+                        error!("No factions loaded...")
+                    }
+                }
+            },
+            Interaction::Hovered | Interaction::None => {}
+        }
+    }
+}
+
+fn btn_interaction_handler(
+    mut query: Query<(&Interaction, &mut BackgroundColor), With<MenuButton>>,
+) {
+    for (interaction, mut bg_colour) in query.iter_mut() {
         match *interaction {
             Interaction::Pressed => {
                 *bg_colour = PRESSED_BUTTON.into();
-                if let Some(factions) = &loaded_factions {
-                    if let Some(selected_faction) = factions.0.first().cloned() {
-                        commands.insert_resource(SelectedFaction(selected_faction));
-                        next_state.set(AppState::Game)
-                    } else {
-                        error!("Couldn't get a faction from loaded factions to set as the selected faction.")
-                    }
-                } else {
-                    error!("No factions loaded...")
-                }
             }
             Interaction::Hovered => {
                 *bg_colour = HOVERED_BUTTON.into();

--- a/src/main_menu/init_screen.rs
+++ b/src/main_menu/init_screen.rs
@@ -113,7 +113,7 @@ fn btn_play_interaction(
         match *interaction {
             Interaction::Pressed => {
                 *bg_colour = PRESSED_BUTTON.into();
-                next_state.set(AppState::LoadGameAssets)
+                next_state.set(AppState::Game)
             }
             Interaction::Hovered => {
                 *bg_colour = HOVERED_BUTTON.into();

--- a/src/main_menu/init_screen.rs
+++ b/src/main_menu/init_screen.rs
@@ -2,7 +2,9 @@
 
 use bevy::prelude::*;
 
+use crate::load_game::load_factions::Factions;
 use crate::main_menu::MainMenuTag;
+use crate::resources::SelectedFaction;
 use crate::AppState;
 
 pub struct InitScreenPlugin<S: States> {
@@ -106,14 +108,25 @@ fn spawn_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 fn btn_play_interaction(
+    mut commands: Commands,
     mut query: Query<(&Interaction, &mut BackgroundColor), With<BtnPlay>>,
     mut next_state: ResMut<NextState<AppState>>,
+    loaded_factions: Option<Res<Factions>>,
 ) {
     for (interaction, mut bg_colour) in &mut query {
         match *interaction {
             Interaction::Pressed => {
                 *bg_colour = PRESSED_BUTTON.into();
-                next_state.set(AppState::Game)
+                if let Some(factions) = &loaded_factions {
+                    if let Some(selected_faction) = factions.0.first().cloned() {
+                        commands.insert_resource(SelectedFaction(selected_faction));
+                        next_state.set(AppState::Game)
+                    } else {
+                        error!("Couldn't get a faction from loaded factions to set as the selected faction.")
+                    }
+                } else {
+                    error!("No factions loaded...")
+                }
             }
             Interaction::Hovered => {
                 *bg_colour = HOVERED_BUTTON.into();

--- a/src/main_menu/init_screen.rs
+++ b/src/main_menu/init_screen.rs
@@ -2,9 +2,10 @@
 
 use bevy::prelude::*;
 
+use crate::game::teams::Team;
 use crate::load_game::load_factions::Factions;
 use crate::main_menu::MainMenuTag;
-use crate::resources::SelectedFaction;
+use crate::resources::PlayerSettings;
 use crate::AppState;
 
 pub struct InitScreenPlugin<S: States> {
@@ -127,7 +128,10 @@ fn btn_action_handler(
                 ButtonAction::Play => {
                     if let Some(factions) = &loaded_factions {
                         if let Some(selected_faction) = factions.0.first().cloned() {
-                            commands.insert_resource(SelectedFaction(selected_faction));
+                            commands.insert_resource(PlayerSettings {
+                                team: Team::Red,
+                                faction: selected_faction,
+                            });
                             next_state.set(AppState::Game)
                         } else {
                             error!("Couldn't get a faction from loaded factions to set as the selected faction.")

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,6 +1,10 @@
+use crate::game::teams::Team;
 use bevy::prelude::*;
 
 use crate::load_game::load_factions::FactionBlueprint;
 
 #[derive(Resource)]
-pub struct SelectedFaction(pub FactionBlueprint);
+pub struct PlayerSettings {
+    pub team: Team,
+    pub faction: FactionBlueprint,
+}

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,0 +1,6 @@
+use bevy::prelude::*;
+
+use crate::load_game::load_factions::FactionBlueprint;
+
+#[derive(Resource)]
+pub struct SelectedFaction(pub FactionBlueprint);

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -8,11 +8,8 @@ pub fn transition_to_game_state(
     mut next_state: ResMut<NextState<AppState>>,
 ) {
     let current_state = simulation_state.get();
-    if keyboard_input.just_pressed(KeyCode::KeyG)
-        && *current_state != AppState::Game
-        && *current_state != AppState::LoadGameAssets
-    {
-        next_state.set(AppState::LoadGameAssets);
+    if keyboard_input.just_pressed(KeyCode::KeyG) && *current_state != AppState::Game {
+        next_state.set(AppState::Game);
         println!("Entered Load Game State")
     }
 }


### PR DESCRIPTION
This code includes:

- Adding building menu UI.
- Setting up building menu buttons to spawn buildings from loaded faction.
- Buildings and units now get their components from the loaded faction.
- A PlayerSettings resource has been added with the one faction we have default selected and team red selected.

![bevy-project-7 - using-faction](https://github.com/phillipphoenix/bevy-castle-fight/assets/1041154/1584cfe4-061d-4bf5-a184-431a325735b2)

Closes #21 